### PR TITLE
回答された際にSlackのDMの内容を更新する実装を追加

### DIFF
--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -28,7 +28,11 @@ class Api::V1::MessagesController < ApplicationController
           button.name = Slack::MessageButton.create_identifier
         end
       end
-      ms.mentions = mentions_params[:mentions].map {|m| Mention.new(m) }
+      ms.mentions = mentions_params[:mentions].map do |m|
+        Mention.new(m).tap do |mention|
+          mention.text = ms.message
+        end
+      end
     end
 
     Message.transaction do

--- a/app/controllers/api/v1/slack/interactive_messages_controller.rb
+++ b/app/controllers/api/v1/slack/interactive_messages_controller.rb
@@ -13,6 +13,7 @@ class Api::V1::Slack::InteractiveMessagesController < ApplicationController
 
     mention.text = "#{mention.text}. #{message_button.text} が選択されました"
     mention.save!
+    MessageButton.update_answered_message(mention.id)
 
     head :created
   end

--- a/app/controllers/api/v1/slack/interactive_messages_controller.rb
+++ b/app/controllers/api/v1/slack/interactive_messages_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::Slack::InteractiveMessagesController < ApplicationController
 
     mention.text = "#{mention.text}. #{message_button.text} が選択されました"
     mention.save!
-    MessageButton.new.update_answered_message(mention.id)
+    Slack::MessageButton.new.update_answered_message(mention.id)
 
     head :created
   end

--- a/app/controllers/api/v1/slack/interactive_messages_controller.rb
+++ b/app/controllers/api/v1/slack/interactive_messages_controller.rb
@@ -11,6 +11,9 @@ class Api::V1::Slack::InteractiveMessagesController < ApplicationController
       mention_id: mention[:id]
     ).save!
 
+    mention.text = "#{mention.text}. #{message_button.text} が選択されました"
+    mention.save!
+
     head :created
   end
 end

--- a/app/controllers/api/v1/slack/interactive_messages_controller.rb
+++ b/app/controllers/api/v1/slack/interactive_messages_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::Slack::InteractiveMessagesController < ApplicationController
 
     mention.text = "#{mention.text}. #{message_button.text} が選択されました"
     mention.save!
-    MessageButton.update_answered_message(mention.id)
+    MessageButton.new.update_answered_message(mention.id)
 
     head :created
   end

--- a/lib/slack/message_button.rb
+++ b/lib/slack/message_button.rb
@@ -69,7 +69,7 @@ module Slack
     end
 
     def update_answered_message(mention_id)
-      chat_update(create_update_params)
+      chat_update(create_update_params(mention_id))
     end
 
     def create_update_params(mention_id)

--- a/lib/slack/message_button.rb
+++ b/lib/slack/message_button.rb
@@ -40,7 +40,16 @@ module Slack
     # @option params [String] :text
     # @see https://github.com/slack-ruby/slack-ruby-client/blob/master/README.md#send-messages
     def chat_update(params = {})
-      client.chat_update(params)
+      Rails.logger.debug(params)
+      begin
+        response = client.chat_update(params)
+        Rails.logger.debug response.inspect
+      rescue => e
+        Rails.logger.error e.inspect
+        raise e
+      end
+
+      response
     end
 
     def disable_previous_message(mention_id)
@@ -56,16 +65,7 @@ module Slack
         attachments: []
       }
 
-      Rails.logger.debug(params)
-      begin
-        response = chat_update(params)
-        Rails.logger.debug response.inspect
-      rescue => e
-        Rails.logger.error e.inspect
-        raise e
-      end
-
-      response
+      chat_update(params)
     end
 
     #

--- a/spec/factories/mention.rb
+++ b/spec/factories/mention.rb
@@ -4,5 +4,8 @@ FactoryGirl.define do
     slack_id { "ABCDEFG0#{id}" }
     name { "USER0#{id}"}
     profile_picture_url { "http://hoge/user0#{id}.jpg" }
+    channel "DXXXXXXXX"
+    ts "1503499924.000735"
+    text "question 000001"
   end
 end

--- a/spec/lib/slack/message_button_spec.rb
+++ b/spec/lib/slack/message_button_spec.rb
@@ -53,4 +53,29 @@ describe Slack::MessageButton do
       it { expect(@result[1][:type]).to eq 'button' }
     end
   end
+
+  describe '#create_update_params' do
+    before do
+      user_with_messages = create(:user, :with_messages)
+      mention_id = user_with_messages.messages.first.mentions.first.id
+
+      @result = slack.send(:create_update_params, mention_id)
+    end
+
+    it { expect(@result[:channel]).to eq 'DXXXXXXXX' }
+    it { expect(@result[:ts]).to eq '1503499924.000735' }
+    it { expect(@result[:text]).to eq 'question 000001' }
+  end
+
+  describe '#effective_buttons' do
+    context 'when has no answer' do
+      before do
+        user_with_messages = create(:user, :with_messages)
+        mention_id = user_with_messages.messages.first.mentions.first.id
+        @result = slack.send(:effective_buttons, mention_id)
+      end
+
+      it { expect(@result.count).to eq 2 }
+    end
+  end
 end

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe "Messages", type: :request do
       expect(parse_response["mentions"].first["slack_id"]).to eq 'UHOGEHOGE'
       expect(parse_response["mentions"].first["name"]).to eq 'fuga'
       expect(parse_response["mentions"].first["profile_picture_url"]).to eq 'http://hoge.com/fuga.jpg'
+      expect(parse_response["mentions"].first["text"]).to eq 'hoge'
     end
 
     it 'enqueue sidekiq' do

--- a/spec/requests/slack/interactive_messages_spec.rb
+++ b/spec/requests/slack/interactive_messages_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe "InteractiveMessages", type: :request do
     let!(:mention) { create(:mention, message: message) }
 
     before do
+      WebMock.stub_request(:post, "https://slack.com/api/chat.update").to_return(
+        body: File.read("#{Rails.root}/test/fixtures/slack_chat_update_response.json"),
+        status: 200,
+        headers: { 'Content-Type' =>  'application/json' })
+
       post "/api/v1/slack/interactive-messages/callback", params:
         {
           actions: [


### PR DESCRIPTION
#54 を受けて、ユーザにDMされている内容を更新する機能を実装した

回答済みかどうかの判定を行う effective_buttons を追加したので、押されたボタンは除外して更新するようになる。

”◯◯が押されました” のようなメッセージも表示したいが、それはコールバックを受けた controller 側で行い、mention に保存する。
